### PR TITLE
Expose additional AST datatypes for downstream use

### DIFF
--- a/src/Language/Wasm.hs
+++ b/src/Language/Wasm.hs
@@ -10,6 +10,12 @@ module Language.Wasm (
     decode,
     decodeLazy,
     Script,
+    Command(..),
+    ModuleDef(..),
+    Action(..),
+    Assertion(..),
+    Ident(..),
+    Meta(..),
     runScript
 ) where
 


### PR DESCRIPTION
I needed to expose some additional datatypes when working on a translator for WebAssembly into our symbolic simulation engine.