### PR TITLE
More Wasm exports needed for Galois crucible tool support.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ library:
   exposed-modules:
   - Language.Wasm.Script
   - Language.Wasm.Lexer
+  - Language.Wasm.Structure
   - Language.Wasm
   dependencies:
   - array                >= 0.5

--- a/src/Language/Wasm.hs
+++ b/src/Language/Wasm.hs
@@ -16,7 +16,8 @@ module Language.Wasm (
     Assertion(..),
     Ident(..),
     Meta(..),
-    runScript
+    runScript,
+    Valid.getModule
 ) where
 
 import qualified Data.ByteString as BS


### PR DESCRIPTION
This covers some additional elements that we need for our Crucible verification suite to support WASM (https://github.com/GaloisInc/crucible).  This was the path of minimal changes, but we're happy to explore alternative export mechanisms if you'd prefer.