### PR TITLE
Allow building with GHC 9.8 and 9.10

### DIFF
--- a/wasm.cabal
+++ b/wasm.cabal
@@ -57,13 +57,13 @@ library
   build-depends:
       array >=0.5 && < 0.6
     , base >=4.6 && < 5
-    , bytestring >=0.10 && < 0.12
+    , bytestring >=0.10 && < 0.13
     , cereal >=0.5 && < 0.6
-    , containers >=0.5 && < 0.7
-    , deepseq >=1.4 && < 1.5
+    , containers >=0.5 && < 0.8
+    , deepseq >=1.4 && < 1.6
     , ieee754 >=0.8 && < 0.9
     , mtl >=2.2.1 && < 2.4
-    , primitive >=0.7 && < 0.8
+    , primitive >=0.7 && < 0.10
     , text >=1.1 && < 3
     , transformers >=0.4 && < 0.7
     , utf8-string >=1.0 && < 1.1


### PR DESCRIPTION
This bumps the upper version bounds on `base`, `bytestring`, `primitive`, and `text` to allow newer versions of each library that build with GHC 9.8 and 9.10.